### PR TITLE
Update nanovna_remote.py

### DIFF
--- a/nanovna_remote.py
+++ b/nanovna_remote.py
@@ -137,7 +137,7 @@ with serial.Serial( nano_tiny_device, timeout=0.5) as nano_tiny: # open serial c
         pil_image = Image.fromarray( rgba8888, 'RGBA' ) # create a PIL image
         image = np.array( pil_image ) # convert from PIL array to np array
         if zoom != 1:
-            image = cv2.resize( image, (zoom * width, zoom * height) ) # resize
+            image = cv2.resize( image, (zoom * width, zoom * height), interpolation = cv2.INTER_AREA ) # resize
         return image
 
 


### PR DESCRIPTION
when zooming this change to the integration argument of cv2.resize() makes the pixels more blocky / retro instead of the fuzzy pixels using the default linear interpolation.